### PR TITLE
Allow pasting of plain text without showing popup

### DIFF
--- a/Resources/public/js/jquery.textarea-markdown.js
+++ b/Resources/public/js/jquery.textarea-markdown.js
@@ -77,7 +77,7 @@
                     markdown,
                     actualEvent = (event.originalEvent || event);
 
-                html = actualEvent.clipboardData.getData('text/html') || window.prompt('Paste something..');
+                html = actualEvent.clipboardData.getData('text/html') || actualEvent.clipboardData.getData('text/plain') || window.prompt('Paste something..');
 
                 // TODO: use CSS styles
 


### PR DESCRIPTION
fixes Peerj/peerj#14232
If check for html in clipboard fails, try plain text before showing paste popup.